### PR TITLE
Allow usage of any monolog version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "squizlabs/php_codesniffer": "dev-master",
         "pda/pheanstalk": "dev-master",
         "iron-io/iron_mq": "dev-master",
-        "monolog/monolog": "dev-master",
+        "monolog/monolog": "*",
         "satooshi/php-coveralls": "dev-master",
         "phpmd/phpmd": "dev-master"
     },


### PR DESCRIPTION
dev-master is 7.0+ only, so that breaks php 5.5 and 5.6 installs