### PR TITLE
Fix attempts handling for PDOEngine-based Engines

### DIFF
--- a/src/josegonzalez/Queuesadilla/Job/Base.php
+++ b/src/josegonzalez/Queuesadilla/Job/Base.php
@@ -62,8 +62,10 @@ class Base implements JsonSerializable
 
     public function release($delay = 0)
     {
-        $this->item['attempts'] = 0;
-        if (isset($this->item['attempts']) && $this->item['attempts'] > 0) {
+        if (!isset($this->item['attempts'])) {
+            $this->item['attempts'] = 0;
+        }
+        if ($this->item['attempts'] > 0) {
             $this->item['attempts'] -= 1;
         }
 

--- a/tests/josegonzalez/Queuesadilla/Engine/AbstractPdoEngineTest.php
+++ b/tests/josegonzalez/Queuesadilla/Engine/AbstractPdoEngineTest.php
@@ -220,7 +220,7 @@ abstract class AbstractPdoEngineTest extends TestCase
         $item = $this->Engine->pop();
         $this->assertTrue($this->Engine->release($item));
         $sth = $this->execute($this->Engine->connection(), 'SELECT * FROM jobs WHERE id = ' . $this->Fixtures->default['first']['id']);
-        $this->assertFalse($sth->rowCount() == 1);
+        $this->assertTrue($sth->rowCount() == 0);
 
         $this->assertTrue($this->Engine->push($this->Fixtures->default['second'], [
             'attempts' => 10
@@ -233,7 +233,7 @@ abstract class AbstractPdoEngineTest extends TestCase
 
         $date = new \DateTime();
         $date->modify('+10 minutes');
-        $sth = $this->execute($this->Engine->connection(), 'SELECT * FROM jobs WHERE id = ' . $this->Fixtures->default['second']['id']);
+        $sth = $this->execute($this->Engine->connection(), 'SELECT * FROM jobs WHERE id = ' . $item2['id']);
         $results = $sth->fetch(PDO::FETCH_ASSOC);
         $inTenMinutes = $date->format('Y-m-d H:i:s');
 


### PR DESCRIPTION
Previously:

- we would incorrectly set attempts, leaving old jobs in the database.
- We rejected all jobs that were released
- Job attributes were updated one by one *after* the lock was released.

now, we update the attributes of the job all at once, allowing us to safely handle job releases.