### PR TITLE
[RFC] Moved common logging events to listeners so they can be overwritten

### DIFF
--- a/src/josegonzalez/Queuesadilla/Worker/Base.php
+++ b/src/josegonzalez/Queuesadilla/Worker/Base.php
@@ -4,12 +4,12 @@ namespace josegonzalez\Queuesadilla\Worker;
 
 use josegonzalez\Queuesadilla\Engine\EngineInterface;
 use josegonzalez\Queuesadilla\Event\EventManagerTrait;
+use josegonzalez\Queuesadilla\Event\MultiEventListener;
 use josegonzalez\Queuesadilla\Utility\LoggerTrait;
 use josegonzalez\Queuesadilla\Worker\Listener\StatsListener;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
-abstract class Base
+abstract class Base extends MultiEventListener
 {
     use EventManagerTrait;
 
@@ -44,6 +44,7 @@ abstract class Base
 
         $this->StatsListener = new StatsListener;
         $this->attachListener($this->StatsListener);
+        $this->attachListener($this);
         register_shutdown_function(array(&$this, 'shutdownHandler'));
 
         return $this;

--- a/src/josegonzalez/Queuesadilla/Worker/Base.php
+++ b/src/josegonzalez/Queuesadilla/Worker/Base.php
@@ -50,6 +50,11 @@ abstract class Base extends MultiEventListener
         return $this;
     }
 
+    public function implementedEvents()
+    {
+        return [];
+    }
+
     public function stats()
     {
         return $this->StatsListener->stats;

--- a/src/josegonzalez/Queuesadilla/Worker/SequentialWorker.php
+++ b/src/josegonzalez/Queuesadilla/Worker/SequentialWorker.php
@@ -203,6 +203,7 @@ class SequentialWorker extends Base
      */
     public function jobEmpty(Event $event)
     {
+        $event;
         $this->logger()->debug('No job!');
     }
 
@@ -226,6 +227,7 @@ class SequentialWorker extends Base
      */
     public function jobSuccess(Event $event)
     {
+        $event;
         $this->logger()->debug('Success. Acknowledging job on queue.');
     }
 }


### PR DESCRIPTION
This is an RFC that suggests that the workers listen the events they dispatch and perform logging in those event methods rather than in the `work()` method.

Why? Well, I'd like to customize these messages and whether or not they are even logged in the first place. For example, I don't want to log "No job!" messages in papertrail but want to use their "inactivity" alert instead. I also want to adjust the success message to include some relevant job information.

Before I go through and listen to everything, I wanted to know if you like this idea, and if so, what events you feel would be worth listening to in this way.