### PR TITLE
Adds release method to PredisEngine

### DIFF
--- a/src/josegonzalez/Queuesadilla/Engine/PredisEngine.php
+++ b/src/josegonzalez/Queuesadilla/Engine/PredisEngine.php
@@ -44,4 +44,16 @@ class PredisEngine extends RedisEngine
             'timeout' => (int)$this->config('timeout'),
         ]);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function release($item, $options = [])
+    {
+        if (isset($item['attempts']) && $item['attempts'] === 0) {
+            return $this->reject($item);
+        }
+
+        return parent::release($item, $options);
+    }
 }


### PR DESCRIPTION
### Summary
The goal of this PR is to allow developers to specify how many times to retry jobs when using the PredisEngine backend.