### PR TITLE
Compatibility with JsonSerializable::jsonSerialize(): mixed

### DIFF
--- a/src/josegonzalez/Queuesadilla/Job/Base.php
+++ b/src/josegonzalez/Queuesadilla/Job/Base.php
@@ -83,7 +83,7 @@ class Base implements JsonSerializable
         return json_encode($this);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->item;
     }


### PR DESCRIPTION
to avoid deprecation error

see https://www.php.net/manual/en/jsonserializable.jsonserialize.php