### PR TITLE
Push method docblock string to array of string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require": {
         "php": ">=7.2.0",
         "psr/log": "~1.0",
-        "league/event": "~2.0",
-        "ext-pcntl": "*"
+        "league/event": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",

--- a/src/josegonzalez/Queuesadilla/Queue.php
+++ b/src/josegonzalez/Queuesadilla/Queue.php
@@ -18,7 +18,7 @@ class Queue
     /**
      * Push a single job onto the queue.
      *
-     * @param string $callable    a job callable
+     * @param string|string[] $callable    a job callable
      * @param array  $args        an array of data to set for the job
      * @param array  $options     an array of options for publishing the job
      *

--- a/src/josegonzalez/Queuesadilla/Worker/SequentialWorker.php
+++ b/src/josegonzalez/Queuesadilla/Worker/SequentialWorker.php
@@ -17,10 +17,6 @@ class SequentialWorker extends Base
     public function __construct(EngineInterface $engine, LoggerInterface $logger = null, $params = [])
     {
         parent::__construct($engine, $logger, $params);
-        pcntl_signal(SIGQUIT, [&$this, 'signalHandler']);
-        pcntl_signal(SIGTERM, [&$this, 'signalHandler']);
-        pcntl_signal(SIGINT, [&$this, 'signalHandler']);
-        pcntl_signal(SIGUSR1, [&$this, 'signalHandler']);
 
         $this->running = true;
     }
@@ -143,45 +139,6 @@ class SequentialWorker extends Base
 
     protected function disconnect()
     {
-    }
-
-    public function signalHandler($signo = null)
-    {
-        $signals = [
-            SIGQUIT => "SIGQUIT",
-            SIGTERM => "SIGTERM",
-            SIGINT => "SIGINT",
-            SIGUSR1 => "SIGUSR1",
-        ];
-
-        if ($signo !== null) {
-            $signal = $signals[$signo];
-            $this->logger->info(sprintf("Received %s... Shutting down", $signal));
-        }
-
-        switch ($signo) {
-            case SIGQUIT:
-                $this->logger()->debug('SIG: Caught SIGQUIT');
-                $this->running = false;
-                break;
-            case SIGTERM:
-                $this->logger()->debug('SIG: Caught SIGTERM');
-                $this->running = false;
-                break;
-            case SIGINT:
-                $this->logger()->debug('SIG: Caught CTRL+C');
-                $this->running = false;
-                break;
-            case SIGUSR1:
-                $this->logger()->debug('SIG: Caught SIGUSR1');
-                $this->running = false;
-                break;
-            default:
-                $this->logger()->debug('SIG:received other signal');
-                break;
-        }
-
-        return true;
     }
 
     public function shutdownHandler($signo = null)


### PR DESCRIPTION
Simple docblock fix for getting type error on IDE. 
`push` method accept either a method name or string of class name and method name. 

```
// Queue up the job
$queue->push(['SomeClass', 'instanceMethod'], [
    'id' => 7,
    'message' => 'hi2u',
]);
```

this block gives warning on IDEs for accepting only string. This PR will fix that